### PR TITLE
:sparkles: Feat: UIErrorboundary, APIErrorProvider, APILoadingProvider 생성

### DIFF
--- a/src/api/AxiosInstance.tsx
+++ b/src/api/AxiosInstance.tsx
@@ -18,4 +18,22 @@ AxiosInstance.interceptors.request.use((config) => {
   return config;
 });
 
+AxiosInstance.interceptors.response.use(
+  (response) => {
+    const newAccessToken = response.headers["x-access-token"];
+    if (newAccessToken) {
+      localStorage.removeItem("accessToken");
+      localStorage.setItem("accessToken", newAccessToken);
+    }
+    return response;
+  },
+  (error) => {
+    if (error.response && error.response.status === 401) {
+      localStorage.removeItem("refreshToken");
+      localStorage.removeItem("accessToken");
+    }
+    return Promise.reject(error);
+  }
+);
+
 export default AxiosInstance;

--- a/src/components/List/index.tsx
+++ b/src/components/List/index.tsx
@@ -3,7 +3,7 @@ import Header from "./Header";
 import RowContainer from "./RowContainer";
 
 export default function List({ children }: React.PropsWithChildren) {
-  return <div className="flex flex-col gap-[15px]">{children}</div>;
+  return <article className="flex flex-col gap-[15px]">{children}</article>;
 }
 
 List.Header = Header;

--- a/src/components/fallback/APIErrorProvider/APIErrorProvider.tsx
+++ b/src/components/fallback/APIErrorProvider/APIErrorProvider.tsx
@@ -1,0 +1,39 @@
+import { PropsWithChildren, createContext, useContext, useState } from "react";
+
+import ErrorFallback from "../ErrorFallback";
+
+type APIErrorContextType = {
+  error: string | null;
+  setAPIError: (errorMessage: string) => void;
+  clearAPIError: () => void;
+};
+
+const APIErrorContext = createContext<APIErrorContextType | undefined>(
+  undefined
+);
+
+export const APIErrorProvider = ({ children }: PropsWithChildren) => {
+  const [error, setError] = useState<string | null>(null);
+
+  const setAPIError = (errorMessage: string) => {
+    setError(errorMessage);
+  };
+
+  const clearAPIError = () => {
+    setError(null);
+  };
+
+  return (
+    <APIErrorContext.Provider value={{ error, setAPIError, clearAPIError }}>
+      {error ? <ErrorFallback message={error} /> : children}
+    </APIErrorContext.Provider>
+  );
+};
+
+export const useAPIError = () => {
+  const context = useContext(APIErrorContext);
+  if (!context) {
+    throw new Error("useAPIError must be used within an APIErrorProvider");
+  }
+  return context;
+};

--- a/src/components/fallback/APIErrorProvider/index.tsx
+++ b/src/components/fallback/APIErrorProvider/index.tsx
@@ -1,0 +1,39 @@
+import { PropsWithChildren, createContext, useContext, useState } from "react";
+
+import ErrorFallback from "../ErrorFallback";
+
+type APIErrorContextType = {
+  error: string | null;
+  setAPIError: (errorMessage: string) => void;
+  clearAPIError: () => void;
+};
+
+const APIErrorContext = createContext<APIErrorContextType | undefined>(
+  undefined
+);
+
+export default function APIErrorProvider({ children }: PropsWithChildren) {
+  const [error, setError] = useState<string | null>(null);
+
+  const setAPIError = (errorMessage: string) => {
+    setError(errorMessage);
+  };
+
+  const clearAPIError = () => {
+    setError(null);
+  };
+
+  return (
+    <APIErrorContext.Provider value={{ error, setAPIError, clearAPIError }}>
+      {error ? <ErrorFallback message={error} /> : children}
+    </APIErrorContext.Provider>
+  );
+}
+
+export const useAPIError = () => {
+  const context = useContext(APIErrorContext);
+  if (!context) {
+    throw new Error("useAPIError must be used within an APIErrorProvider");
+  }
+  return context;
+};

--- a/src/components/fallback/APILoadingProvider/index.tsx
+++ b/src/components/fallback/APILoadingProvider/index.tsx
@@ -1,0 +1,41 @@
+import { PropsWithChildren, createContext, useContext, useState } from "react";
+
+import LoadingFallback from "../LoadingFallback";
+
+type APILoadingContextType = {
+  loading: boolean;
+  setAPILoading: () => void;
+  clearAPILoading: () => void;
+};
+
+const APILoadingContext = createContext<APILoadingContextType | undefined>(
+  undefined
+);
+
+export default function APILoadingProvider({ children }: PropsWithChildren) {
+  const [loading, setLoading] = useState(false);
+
+  const setAPILoading = () => {
+    setLoading(true);
+  };
+
+  const clearAPILoading = () => {
+    setLoading(false);
+  };
+
+  return (
+    <APILoadingContext.Provider
+      value={{ loading, setAPILoading, clearAPILoading }}
+    >
+      {loading ? <LoadingFallback /> : children}
+    </APILoadingContext.Provider>
+  );
+}
+
+export const useAPILoading = () => {
+  const context = useContext(APILoadingContext);
+  if (!context) {
+    throw new Error("useAPILoading must be used within an APILoadingProvider");
+  }
+  return context;
+};

--- a/src/components/fallback/UIErrorBoundary/index.tsx
+++ b/src/components/fallback/UIErrorBoundary/index.tsx
@@ -1,0 +1,39 @@
+import { Component, ErrorInfo, ReactNode } from "react";
+
+import ErrorFallback from "../ErrorFallback";
+
+interface UIErrorBoundaryProps {
+  children: ReactNode;
+}
+
+interface UIErrorBoundaryState {
+  hasError: boolean;
+}
+
+class UIErrorBoundary extends Component<
+  UIErrorBoundaryProps,
+  UIErrorBoundaryState
+> {
+  constructor(props: UIErrorBoundaryProps) {
+    super(props);
+    this.state = { hasError: false };
+  }
+
+  static getDerivedStateFromError(): UIErrorBoundaryState {
+    return { hasError: true };
+  }
+
+  componentDidCatch(error: Error, errorInfo: ErrorInfo): void {
+    console.error("에러 발생:", error, errorInfo);
+  }
+
+  render() {
+    if (this.state.hasError) {
+      return <ErrorFallback />;
+    }
+
+    return this.props.children;
+  }
+}
+
+export default UIErrorBoundary;

--- a/src/pages/errors/Error.tsx
+++ b/src/pages/errors/Error.tsx
@@ -1,5 +1,7 @@
+import DefaultLayout from "../../layouts/DefaultLayout";
+
 const ErrorPage = () => {
-  return <main>에러가 발생했습니다.</main>;
+  return <div>에러가 발생했습니다.</div>;
 };
 
 export default ErrorPage;

--- a/src/pages/essay/List.tsx
+++ b/src/pages/essay/List.tsx
@@ -3,6 +3,7 @@ import APIErrorProvider, {
 } from "../../components/fallback/APIErrorProvider";
 import { Link, useLoaderData } from "react-router-dom";
 
+import APILoadingProvider from "../../components/fallback/APILoadingProvider";
 import { EssayListResponseType } from "../../api/essays/getEssayList";
 import { EssayListType } from "../../api/essays";
 import List from "../../components/List";
@@ -19,7 +20,9 @@ export default function EssayList() {
   return (
     <UIErrorBoundary>
       <APIErrorProvider>
-        <EssayListContent />
+        <APILoadingProvider>
+          <EssayListContent />
+        </APILoadingProvider>
       </APIErrorProvider>
     </UIErrorBoundary>
   );

--- a/src/pages/essay/List.tsx
+++ b/src/pages/essay/List.tsx
@@ -1,11 +1,14 @@
+import APIErrorProvider, {
+  useAPIError,
+} from "../../components/fallback/APIErrorProvider";
 import { Link, useLoaderData } from "react-router-dom";
 
-import ErrorFallback from "../../components/fallback/ErrorFallback";
 import { EssayListResponseType } from "../../api/essays/getEssayList";
 import { EssayListType } from "../../api/essays";
 import List from "../../components/List";
 import LoadingFallback from "../../components/fallback/LoadingFallback";
 import Pagination from "../../components/Pagination";
+import UIErrorBoundary from "../../components/fallback/UIErrorBoundary";
 import essayQueryOptions from "../../queries/essayQueryOptions";
 import usePagination from "../../components/Pagination/usePagination";
 import { useQuery } from "@tanstack/react-query";
@@ -13,6 +16,7 @@ import { useQuery } from "@tanstack/react-query";
 const EssayListColumns = ["ID", "에세이 제목", "저자", "발행일자", "조회수"];
 
 const EssayList = () => {
+  const { setAPIError } = useAPIError();
   const initialData = useLoaderData<EssayListResponseType>();
   const { currentPage, handlePaginationEvent } = usePagination(
     initialData.totalPage
@@ -26,25 +30,30 @@ const EssayList = () => {
   });
 
   if (isLoading) return <LoadingFallback />;
-  if (error instanceof Error) return <ErrorFallback />;
+  if (error instanceof Error) {
+    setAPIError(error.message);
+    return;
+  }
 
   return (
-    <main>
-      <List>
-        <List.Header totalCount={data.data.total} label="에세이" />
-        <List.ColumnContainer headers={EssayListColumns} row={5} />
-        <List.RowContainer>
-          {data.data.essays.map((essay) => (
-            <EssayListItem key={essay.id} {...essay} />
-          ))}
-        </List.RowContainer>
-        <Pagination
-          totalPages={data.data.totalPage}
-          currentPage={currentPage}
-          handlePaginationEvent={handlePaginationEvent}
-        />
-      </List>
-    </main>
+    <UIErrorBoundary>
+      <APIErrorProvider>
+        <List>
+          <List.Header totalCount={data.data.total} label="에세이" />
+          <List.ColumnContainer headers={EssayListColumns} row={5} />
+          <List.RowContainer>
+            {data.data.essays.map((essay) => (
+              <EssayListItem key={essay.id} {...essay} />
+            ))}
+          </List.RowContainer>
+          <Pagination
+            totalPages={data.data.totalPage}
+            currentPage={currentPage}
+            handlePaginationEvent={handlePaginationEvent}
+          />
+        </List>
+      </APIErrorProvider>
+    </UIErrorBoundary>
   );
 };
 

--- a/src/pages/essay/List.tsx
+++ b/src/pages/essay/List.tsx
@@ -15,7 +15,17 @@ import { useQuery } from "@tanstack/react-query";
 
 const EssayListColumns = ["ID", "에세이 제목", "저자", "발행일자", "조회수"];
 
-const EssayList = () => {
+export default function EssayList() {
+  return (
+    <UIErrorBoundary>
+      <APIErrorProvider>
+        <EssayListContent />
+      </APIErrorProvider>
+    </UIErrorBoundary>
+  );
+}
+
+const EssayListContent = () => {
   const { setAPIError } = useAPIError();
   const initialData = useLoaderData<EssayListResponseType>();
   const { currentPage, handlePaginationEvent } = usePagination(
@@ -36,28 +46,22 @@ const EssayList = () => {
   }
 
   return (
-    <UIErrorBoundary>
-      <APIErrorProvider>
-        <List>
-          <List.Header totalCount={data.data.total} label="에세이" />
-          <List.ColumnContainer headers={EssayListColumns} row={5} />
-          <List.RowContainer>
-            {data.data.essays.map((essay) => (
-              <EssayListItem key={essay.id} {...essay} />
-            ))}
-          </List.RowContainer>
-          <Pagination
-            totalPages={data.data.totalPage}
-            currentPage={currentPage}
-            handlePaginationEvent={handlePaginationEvent}
-          />
-        </List>
-      </APIErrorProvider>
-    </UIErrorBoundary>
+    <List>
+      <List.Header totalCount={data.data.total} label="에세이" />
+      <List.ColumnContainer headers={EssayListColumns} row={5} />
+      <List.RowContainer>
+        {data.data.essays.map((essay) => (
+          <EssayListItem key={essay.id} {...essay} />
+        ))}
+      </List.RowContainer>
+      <Pagination
+        totalPages={data.data.totalPage}
+        currentPage={currentPage}
+        handlePaginationEvent={handlePaginationEvent}
+      />
+    </List>
   );
 };
-
-export default EssayList;
 
 type EssayListItemProps = EssayListType;
 

--- a/src/pages/essay/List.tsx
+++ b/src/pages/essay/List.tsx
@@ -1,13 +1,14 @@
 import APIErrorProvider, {
   useAPIError,
 } from "../../components/fallback/APIErrorProvider";
+import APILoadingProvider, {
+  useAPILoading,
+} from "../../components/fallback/APILoadingProvider";
 import { Link, useLoaderData } from "react-router-dom";
 
-import APILoadingProvider from "../../components/fallback/APILoadingProvider";
 import { EssayListResponseType } from "../../api/essays/getEssayList";
 import { EssayListType } from "../../api/essays";
 import List from "../../components/List";
-import LoadingFallback from "../../components/fallback/LoadingFallback";
 import Pagination from "../../components/Pagination";
 import UIErrorBoundary from "../../components/fallback/UIErrorBoundary";
 import essayQueryOptions from "../../queries/essayQueryOptions";
@@ -30,6 +31,7 @@ export default function EssayList() {
 
 const EssayListContent = () => {
   const { setAPIError } = useAPIError();
+  const { setAPILoading } = useAPILoading();
   const initialData = useLoaderData<EssayListResponseType>();
   const { currentPage, handlePaginationEvent } = usePagination(
     initialData.totalPage
@@ -42,7 +44,10 @@ const EssayListContent = () => {
     initialData: { data: initialData },
   });
 
-  if (isLoading) return <LoadingFallback />;
+  if (isLoading) {
+    setAPILoading();
+    return;
+  }
   if (error instanceof Error) {
     setAPIError(error.message);
     return;

--- a/src/router/router.tsx
+++ b/src/router/router.tsx
@@ -18,7 +18,6 @@ const router = createBrowserRouter([
   {
     path: "/",
     element: <DefaultLayout />,
-    errorElement: <ErrorPage />,
     loader: checkDefaultLoader,
     children: [
       { path: DefaultPaths.DASHBOARD, element: <Dashboard /> },


### PR DESCRIPTION
# Linked Out Admin Page Pull Request
## Summary

UIErrorboundary, APIErrorProvider, APILoadingProvider 생성

## Related Issues

<!-- List any related issues, e.g., #1234, if applicable. -->

## Changes

<!-- Describe the main changes in this PR, including new features, bug fixes, etc. -->
- UIErrorboundary를 통한 렌더링 에러 감지
- APIErrorProvider를 통한 API 에러 중앙 관리
- APILoadingProvider를 통한 API 로딩 상태 중앙 관리
- 직관적인 에러 케이스 구분 네이밍

## Screenshots

<!-- Add screenshots or GIFs to show how the changes look, if applicable. -->

![image](https://github.com/user-attachments/assets/ec308604-974e-4e4f-a27c-6e7cdd8cf868)
![image](https://github.com/user-attachments/assets/ef936bf7-7df3-413d-bcba-b88a1f565033)

## Additional Notes

<!-- Add any other comments or information. -->

- 에러 및 로딩 상태의 중앙 관리가 실제로 편의성 향상에 기여하는지는 좀 더 지켜봐야함