### PR TITLE
🔥 Improve: onMouseOut 시 요청 취소 및 cacheTime 설정

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -3,8 +3,16 @@ import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { RouterProvider } from "react-router-dom";
 import router from "./router/router";
 
-export const queryClient = new QueryClient();
-
+export const queryClient = new QueryClient({
+  defaultOptions: {
+    queries: {
+      staleTime: 1000 * 60 * 5,
+      gcTime: 1000 * 60 * 30,
+      refetchOnWindowFocus: false,
+      refetchOnReconnect: false,
+    },
+  },
+});
 const App = () => {
   return (
     <QueryClientProvider client={queryClient}>

--- a/src/components/GNB/Nav.tsx
+++ b/src/components/GNB/Nav.tsx
@@ -1,13 +1,12 @@
+import { QueryFunction, useQueryClient } from "@tanstack/react-query";
 import { useRef, useState } from "react";
 
 import { DefaultPaths } from "../../router/paths";
 import { Link } from "react-router-dom";
-import { QueryFunction } from "@tanstack/react-query";
 import { cn } from "../../lib/utils";
 import essayQueryOptions from "../../queries/essayQueryOptions";
 import geulroquisQueryOptions from "../../queries/geulroquisQueryOptions";
 import managerQueryOptions from "../../queries/managerQueryOptions";
-import { queryClient } from "../../App";
 import sprite from "../../assets/SVGsprite.svg";
 import themeQueryOptions from "../../queries/themeQueryOptions";
 import userQueryOptions from "../../queries/userQueryOptions";
@@ -43,7 +42,6 @@ const items: NavItemType[] = [
     }).queryKey,
     queryFn: essayQueryOptions.getEssayList({
       pagination: { page: 1, perPage: 10 },
-      filter: { keyword: "" },
     }).queryFn,
   },
   { iconId: "report-list", label: "레포트 목록", to: DefaultPaths.REPORT.LIST },
@@ -123,6 +121,7 @@ const Nav = () => {
 export default Nav;
 
 const NavItem = ({ iconId, label, to, queryKey, queryFn }: NavItemType) => {
+  const queryClient = useQueryClient();
   const abortControllerRef = useRef<AbortController | null>(null);
 
   const handleMouseOver = () => {
@@ -134,7 +133,6 @@ const NavItem = ({ iconId, label, to, queryKey, queryFn }: NavItemType) => {
 
     const controller = new AbortController();
     abortControllerRef.current = controller;
-    console.log("Fetching with AbortController signal:", controller.signal);
     queryClient.fetchQuery({
       queryKey,
       queryFn: () =>
@@ -143,6 +141,8 @@ const NavItem = ({ iconId, label, to, queryKey, queryFn }: NavItemType) => {
           queryKey,
           meta: undefined,
         }),
+      staleTime: 1000 * 60 * 5,
+      gcTime: 1000 * 60 * 10,
     });
   };
 

--- a/src/queries/essayQueryOptions.ts
+++ b/src/queries/essayQueryOptions.ts
@@ -7,7 +7,13 @@ import { queryOptions } from "@tanstack/react-query";
 const essayQueryOptions = {
   getEssayList: (params: ListParams) =>
     queryOptions({
-      queryKey: ["essay", "list", params],
+      queryKey: [
+        "essay",
+        "list",
+        params.pagination.page,
+        params.pagination.perPage,
+        params.filter?.keyword || "",
+      ],
       queryFn: () => getEssayList(params),
     }),
   getEssayDetail: (params: DetailParams) =>

--- a/src/queries/userQueryOptions.ts
+++ b/src/queries/userQueryOptions.ts
@@ -7,7 +7,13 @@ import { queryOptions } from "@tanstack/react-query";
 const userQueryOptions = {
   getUserList: (params: ListParams) =>
     queryOptions({
-      queryKey: ["user", "list", params],
+      queryKey: [
+        "user",
+        "list",
+        params.pagination.page,
+        params.pagination.perPage,
+        params.filter?.keyword || "",
+      ],
       queryFn: () => getUserList(params),
     }),
   getUserDetail: (params: DetailParams) =>


### PR DESCRIPTION
# 🌌 Linked Out Admin Page Pull Request

## ✨ Summary

<!-- Provide a concise summary of the changes in this PR. -->
onMouseOut 시 요청 취소 및 cacheTime 설정

## 🔨 Changes

<!-- Describe the main changes in this PR, including new features, bug fixes, etc. -->

- AbortController를 통해 api 요청 제어
- cacheTime 설정 및 queryKey 정확한 지정을 통해 캐시 데이터 활용

## 📸 Screenshots

<!-- Add screenshots or GIFs to show how the changes look, if applicable. -->

![제목 없는 동영상 - Clipchamp로 제작](https://github.com/user-attachments/assets/6cc4735c-2a6b-4907-bbfe-573f420b1388)

