### PR TITLE
🔥 Improve: List 컴포넌트 내부에서 Blank 렌더링

### DIFF
--- a/src/components/List/RowContainer/index.tsx
+++ b/src/components/List/RowContainer/index.tsx
@@ -1,5 +1,8 @@
-import { PropsWithChildren } from "react";
+import React, { PropsWithChildren } from "react";
+
+import Blank from "../../fallback/Blank";
 import { cn } from "../../../lib/utils";
+import { hasValidChildren } from "../../../lib/node.utils";
 
 type RowContainerProps = {
   row: number;
@@ -11,6 +14,10 @@ export default function RowContainer({
   className,
   children,
 }: RowContainerProps) {
+  if (!hasValidChildren(children)) {
+    return <Blank />;
+  }
+
   return (
     <div className={cn(`grid grid-rows-${row}`, className)}>{children}</div>
   );

--- a/src/components/List/RowContainer/index.tsx
+++ b/src/components/List/RowContainer/index.tsx
@@ -1,6 +1,5 @@
-import React, { PropsWithChildren } from "react";
-
 import Blank from "../../fallback/Blank";
+import { PropsWithChildren } from "react";
 import { cn } from "../../../lib/utils";
 import { hasValidChildren } from "../../../lib/node.utils";
 

--- a/src/components/List/index.stories.tsx
+++ b/src/components/List/index.stories.tsx
@@ -23,6 +23,20 @@ export const Default = {
   ),
 };
 
+export const Blank = {
+  render: () => (
+    <List>
+      <List.Header totalCount={47} label="책" />
+      <List.ColumnContainer headers={headers} row={5} />
+      <List.RowContainer row={10}>
+        {no_books.map((book) => (
+          <ListItemStory key={book.id} {...book} />
+        ))}
+      </List.RowContainer>
+    </List>
+  ),
+};
+
 type BookItemType = {
   id: string;
   title: string;
@@ -104,6 +118,8 @@ const books: BookItemType[] = [
     etc: "Inspirational story",
   },
 ];
+
+const no_books: BookItemType[] = [];
 
 const ListItemStory = ({ id, title, author, publisher, etc }: BookItemType) => {
   return (

--- a/src/lib/node.spec.tsx
+++ b/src/lib/node.spec.tsx
@@ -1,0 +1,11 @@
+import { hasValidChildren } from "./node.utils";
+
+test("return true for valid children case", () => {
+  const children = [<div key="1">Valid</div>, "Text"];
+  expect(hasValidChildren(children)).toBe(true);
+});
+
+test("return false for invalid or empty children case", () => {
+  const children = [null, undefined, false];
+  expect(hasValidChildren(children)).toBe(false);
+});

--- a/src/lib/node.utils.ts
+++ b/src/lib/node.utils.ts
@@ -1,0 +1,10 @@
+import React from "react";
+
+export function hasValidChildren(children: React.ReactNode): boolean {
+  return React.Children.toArray(children).some(
+    (child) =>
+      React.isValidElement(child) ||
+      typeof child === "string" ||
+      typeof child === "number"
+  );
+}

--- a/src/pages/user/List.tsx
+++ b/src/pages/user/List.tsx
@@ -80,11 +80,9 @@ const UserListContent = () => {
       </List.Header>
       <List.ColumnContainer headers={userListColumns} row={5} />
       <List.RowContainer row={10}>
-        {!data.users || data.users.length === 0 ? (
-          <Blank />
-        ) : (
-          data.users.map((user) => <UserListItem key={user.id} {...user} />)
-        )}
+        {data.users.map((user) => (
+          <UserListItem key={user.id} {...user} />
+        ))}
       </List.RowContainer>
       <Pagination
         totalPages={data.totalPage}


### PR DESCRIPTION
# 🌌 Linked Out Admin Page Pull Request

## ✨ Summary

<!-- Provide a concise summary of the changes in this PR. -->

외부에서 배열 길이 조건부 렌더링 => List 컴포넌트 내부에서 처리하도록 변경

## 🔗 Related Issues

<!-- List any related issues, e.g., #1234, if applicable. -->

## 🔨 Changes

<!-- Describe the main changes in this PR, including new features, bug fixes, etc. -->

- 유효한 children이 없는 경우, RowContainer 내부에서 <Blank /> 컴포넌트를 반환
- hasValidChildren 유틸리티 함수로 children의 유효성 검사

## 💬 Additional Notes

<!-- Add any other comments or information. -->

`React.Children.toArray`를 통해 배열로 만든 후 유효 node 체크